### PR TITLE
解决从口袋掏出设备或扣在桌面重新拿起时可能发生的亮度激增的问题

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.ztc1997.fakedcbacklight">
 
-    <uses-feature android:name="android.software.companion_device_setup"/>
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-feature android:name="android.software.companion_device_setup" />
+
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <uses-permission
+        android:name="android.permission.WRITE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="true"
@@ -11,12 +16,21 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme">
+
+        <receiver
+            android:name=".SettingsActivity$ScreenListener"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.SCREEN_OFF" />
+                <action android:name="android.intent.action.SCREEN_ON" />
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name=".SettingsActivity"
-            android:launchMode="singleInstance"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/ztc1997/fakedcbacklight/SettingsActivity.kt
+++ b/app/src/main/java/com/ztc1997/fakedcbacklight/SettingsActivity.kt
@@ -69,11 +69,13 @@ class SettingsActivity : Activity() {
                                 0
                             )
                         if (Intent.ACTION_SCREEN_ON.equals(intent.action)) {
-                            Settings.System.putInt(
-                                ctx.contentResolver,
-                                "screen_brightness_mode",
-                                1
-                            )
+                            Handler().postDelayed({
+                                Settings.System.putInt(
+                                    ctx.contentResolver,
+                                    "screen_brightness_mode",
+                                    1
+                                )
+                            },1000)
                         }
                     }
                 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -16,4 +16,6 @@
     <string name="xposeddescription">在亮度低于最低屏幕亮度时启用极暗</string>
     <string name="title_pref_hal_brightness">当前 HAL 亮度</string>
     <string name="summary_pref_hal_brightness">无法获取 HAL 亮度，激活模块并重启，然后重试</string>
+    <string name="title_off_screen_optim">息屏优化</string>
+    <string name="summary_off_screen_optim">若设备从口袋掏出或扣在桌子上重新拿起时发生亮度急剧增加，尝试勾选</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="xposeddescription">Enable Extra dim when the brightness is lower than the minimum screen brightness.</string>
     <string name="title_pref_hal_brightness">Current HAL Brightness</string>
     <string name="summary_pref_hal_brightness">Cannot obtain HAL Brightness, Activate the module and reboot and try again</string>
+    <string name="title_off_screen_optim">Off Screen Optimization</string>
+    <string name="summary_off_screen_optim">When the device is pulled out or buckled on the table and re -picked up, if the brightness increases sharply, try to check</string>
 </resources>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -7,6 +7,11 @@
             android:defaultValue="true"
             android:key="pref_enable"
             android:title="@string/title_pref_enable" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="off_screen_optim"
+            android:summary="@string/summary_off_screen_optim"
+            android:title="@string/title_off_screen_optim" />
         <EditTextPreference
             android:defaultValue="100"
             android:key="pref_min_screen_bright"


### PR DESCRIPTION
解决方法: 息屏时暂停自动亮度调节